### PR TITLE
Add pipeline for building buildtools docker images

### DIFF
--- a/vars/buildtoolsBuildSingleDockerImage.groovy
+++ b/vars/buildtoolsBuildSingleDockerImage.groovy
@@ -7,6 +7,7 @@ def call(Map parameters = [:]) {
   // Extract all parameters so that it is easy to see which parameters
   // are available.
   def dockerImageName = parameters.dockerImage
+  def dockerImageTag = parameters.dockerImageTag ?: 'latest'
   def testImageHook = parameters.testImageHook
 
   buildConfig([
@@ -42,9 +43,8 @@ def call(Map parameters = [:]) {
 
       if (env.BRANCH_NAME == 'master' && !isSameImage) {
         stage('Push Docker image') {
-          def tagName = 'latest'
-          img.push(tagName)
-          slackNotify message: "New Docker image available: $dockerImageName:$tagName"
+          img.push(dockerImageTag)
+          slackNotify message: "New Docker image available: $dockerImageName:$dockerImageTag"
         }
       }
     }


### PR DESCRIPTION
This is a first attempt of how we can build abstractions to keep only minimum configuration in the separate repositories. See usage in https://github.com/capralifecycle/sonar-scanner-docker/pull/1

Similar setup can be done for other project types / types of pipelines.

Should we also abstract away the AWS account ID so that we only specify the repository name on ECR, not the full path?