### PR TITLE
Fix path for deploying release artifact

### DIFF
--- a/src/no/capraconsulting/buildtools/serverlessjavapipeline/ServerlessJavaPipeline.groovy
+++ b/src/no/capraconsulting/buildtools/serverlessjavapipeline/ServerlessJavaPipeline.groovy
@@ -116,7 +116,7 @@ def pipeline(Closure cl) {
             serverlessDeploy(
               config.deployProd.iamRole,
               [
-                "--artifact target/${artifactId}-${releaseVersion}.jar",
+                "--artifact target/checkout/target/${artifactId}-${releaseVersion}.jar",
                 "--stage ${config.deployProd.stage}",
                 "--region ${config.deployProd.region}",
               ].join(' ')


### PR DESCRIPTION
Release artifact is stored in `target/checkout/target` instead of the usual `target/checkout` folder