### PR TITLE
withAwsRole: Don't leak credentials in env

### DIFF
--- a/vars/withAwsRole.groovy
+++ b/vars/withAwsRole.groovy
@@ -59,10 +59,5 @@ def call(roleArn, body) {
 }
 
 def tempFileName() {
-  pwd(tmp: true) + '/' + generator(('a'..'z').join(''), 15)
-}
-
-def generator(String alphabet, int n) {
-  def rand = new Random()
-  (1..n).collect { alphabet[rand.nextInt(alphabet.length())] }.join('')
+  pwd(tmp: true) + '/' + UUID.randomUUID().toString()
 }


### PR DESCRIPTION
This mitigates the credentials to leak if environment variables
are printed within the body of this call.

---

I found I had already made this workaround in #8

Tested in https://github.com/capralifecycle/hst-jenkinstest/blob/3781294d0f104213628920648866cd0ca4fbbfaa/Jenkinsfile

https://jenkins.capra.tv/job/hst-jenkinstest/job/hide-aws-creds/17/console