### PR TITLE
Add initial SonarCloud integration

### DIFF
--- a/vars/analyzeSonarCloud.groovy
+++ b/vars/analyzeSonarCloud.groovy
@@ -1,0 +1,123 @@
+#!/usr/bin/groovy
+
+/**
+ * Analyze the project using SonarScanner and upload to SonarCloud.
+ *
+ * See also the following preferred high-level facades:
+ *   - analyzeSonarCloudForMaven
+ *   - analyzeSonarCloudForNodejs
+ *
+ * This must be called in a context that contains:
+ *   - sonar-scanner
+ *   - git
+ *
+ * See https://confluence.capraconsulting.no/x/dA9aBw for internal details.
+ */
+def call(Map<String, String> params, Map<String, String> options = [:]) {
+  requireValue(params, 'sonar.projectKey')
+  requireValue(params, 'sonar.organization')
+  requireBinary('sonar-scanner')
+  requireBinary('git')
+
+  def defaultBranch = options.get('defaultBranch', 'master')
+  def orgAndRepo = getGitHubOrganizationAndRepoName().join('/')
+
+  // SonarScanner wants target branch to be fetched, or else we will get
+  // "WARN: Could not find ref: master in refs/heads or refs/remotes/origin"
+  def target = env.CHANGE_TARGET ? env.CHANGE_TARGET : defaultBranch
+  if (env.BRANCH_NAME != target) {
+    withGitTokenCredentials {
+      sh """
+        if ! git rev-parse --verify origin/$target; then
+          git fetch --no-tags origin +refs/heads/$target:refs/remotes/origin/$target
+        fi
+      """
+    }
+  }
+
+  stage('SonarScanner with SonarCloud') {
+    withCredentials([
+      string(
+        credentialsId: 'sonarcloud-calsci-token',
+        variable: 'SONARCLOUD_TOKEN',
+      ),
+    ]) {
+      // Build base parameters. Provided parameters can override.
+      Map<String, String> p = [:]
+
+      p['sonar.host.url'] = 'https://sonarcloud.io'
+      p['sonar.login'] = env.SONARCLOUD_TOKEN
+
+      if (env.CHANGE_ID) {
+        // https://sonarcloud.io/documentation/analysis/pull-request/
+        p['sonar.pullrequest.base'] = env.CHANGE_TARGET
+        p['sonar.pullrequest.branch'] = env.BRANCH_NAME
+        p['sonar.pullrequest.key'] = env.CHANGE_ID
+        p['sonar.pullrequest.provider'] = 'GitHub'
+        p['sonar.pullrequest.github.repository'] = orgAndRepo
+
+        // Detect the actual commit that is used. Jenkins will create a
+        // merge commit when doing pr-merge strategy which SonarCloud will
+        // never know about.
+        p['sonar.scm.revision'] = sh(
+          returnStdout: true,
+          script: '''
+            if git show -s --format=%s HEAD | grep -q '^Merge commit '; then
+              git rev-parse HEAD~1
+            else
+              git rev-parse HEAD
+            fi
+          ''',
+        ).trim()
+      } else {
+        // https://sonarcloud.io/documentation/branches/overview/
+        p['sonar.branch.name'] = env.BRANCH_NAME
+      }
+
+      def finalParams = (p + params)
+        .collect { k, v ->
+          "$k=$v"
+        }
+        .join("\n")
+
+      // Write properties to file instead of trying to pass them as parameters.
+
+      def propertiesFile = pwd(tmp: true) + '/sonar-project.properties'
+      writeFile(
+        file: propertiesFile,
+        text: finalParams,
+        encoding: 'utf-8',
+      )
+
+      // The token will be masked by the credentials plugin.
+      echo "Executing sonar-scanner with these parameters:\n$finalParams"
+
+      sh "sonar-scanner -Dproject.settings='${propertiesFile}'"
+    }
+  }
+}
+
+def getGitHubOrganizationAndRepoName() {
+  // Support both https and ssh formats.
+  def parts = sh(returnStdout: true, script: 'git remote get-url origin')
+    .trim()
+    .split(':')[-1]
+    .replaceAll(/\.git$/, '')
+    .split('/')
+
+  // Returns [orgName, repoName]
+  return [parts[-2], parts[-1]]
+}
+
+def requireBinary(name) {
+  def found = sh(returnStdout: true, script: "which $name >/dev/null && echo 1 || echo 0").trim()
+  if (found != "1") {
+    error("Binary `$name` was not found. You need to call analyzeSonarCloud inside an image that contains `$name`.")
+  }
+}
+
+def requireValue(map, name) {
+  if (!(name in map)) {
+    error("$name must be set in parameter list to analyzeSonarCloud")
+  }
+}

--- a/vars/analyzeSonarCloudForJs.groovy
+++ b/vars/analyzeSonarCloudForJs.groovy
@@ -1,0 +1,56 @@
+#!/usr/bin/groovy
+
+/**
+ * Analyze a Node.js project using SonarScanner and upload to SonarCloud.
+ *
+ * This is a high-level facade that adheres to our preferred setup.
+ *
+ * See analyzeSonarCloud for runtime requirements.
+ *
+ * Setup instructions:
+ *   1) Create project in sonarcloud.io
+ *   2) Install jest reporter:
+ *      npm install --save-dev --exact jest-sonar-reporter
+ *   3) Add to .gitignore:
+ *      /coverage/
+ *      /test-report.xml
+ *   4) Modify package.json and ensure jest is called with `--coverage`
+ *      E.g. "jest --coverage src"
+ *   5) Add to jest config:
+ *      { testResultsProcessor: 'jest-sonar-reporter' }
+ *   6) Ensure the image being used in the build includes sonar-scanner
+ *      See e.g https://github.com/capralifecycle/buildtools-snippets/tree/master/tools/sonar-scanner
+ *      (at least for TypeScript the sonar-scanner needs the node executable)
+ *   7) Add to Jenkinsfile (outside a stage)
+ *      analyzeSonarCloudForJs([
+ *        // Modify next lines and remove this comment.
+ *        'sonar.organization': 'capralifecycle',
+ *        'sonar.projectKey': 'capralifecycle_my-project',
+ *      ])
+ */
+def call(Map<String, String> params, Map<String, String> options = [:]) {
+  p = [
+    'sonar.typescript.lcov.reportPaths': 'coverage/lcov.info',
+    'sonar.javascript.lcov.reportPaths': 'coverage/lcov.info',
+    'sonar.sources': 'src',
+    'sonar.tests': 'src',
+    'sonar.test.inclusions': [
+      'src/**/*.spec.js',
+      'src/**/*.spec.jsx',
+      'src/**/*.spec.ts',
+      'src/**/*.spec.tsx',
+      'src/**/*.test.js',
+      'src/**/*.test.jsx',
+      'src/**/*.test.ts',
+      'src/**/*.test.tsx',
+    ].join(','),
+  ] + params
+
+  if (fileExists('test-report.xml')) {
+    p['sonar.testExecutionReportPaths'] = 'test-report.xml'
+  } else {
+    echo 'WARN: test-report.xml does not exist. Test output not correctly set up?'
+  }
+
+  analyzeSonarCloud(p, options)
+}

--- a/vars/analyzeSonarCloudForMaven.groovy
+++ b/vars/analyzeSonarCloudForMaven.groovy
@@ -1,0 +1,57 @@
+#!/usr/bin/groovy
+
+/**
+ * Analyze a Maven project using SonarScanner and upload to SonarCloud.
+ *
+ * This is a high-level facade that adheres to our preferred setup.
+ *
+ * See analyzeSonarCloud for runtime requirements.
+ *
+ * Setup instructions:
+ *   1) Create project in sonarcloud.io
+ *   2) Add to project.build.plugins in pom.xml (ensure you check for latest version):
+ *      <!-- Coverage for SonarCloud -->
+ *      <plugin>
+ *        <groupId>org.jacoco</groupId>
+ *        <artifactId>jacoco-maven-plugin</artifactId>
+ *        <version>0.8.4</version>
+ *        <executions>
+ *          <execution>
+ *            <id>jacoco-initialize</id>
+ *            <goals>
+ *              <goal>prepare-agent</goal>
+ *            </goals>
+ *          </execution>
+ *          <execution>
+ *            <id>jacoco-site</id>
+ *            <goals>
+ *              <goal>report</goal>
+ *            </goals>
+ *          </execution>
+ *        </executions>
+ *      </plugin>
+ *   3) Ensure the image being used in the build includes sonar-scanner
+ *      See e.g. https://github.com/capralifecycle/buildtools-snippets/tree/master/tools/sonar-scanner
+ *      or use insideSonarScanner
+ *   4) Add to Jenkinsfile (outside a stage)
+ *      analyzeSonarCloudForMaven([
+ *        // Modify next lines and remove this comment.
+ *        'sonar.organization': 'capralifecycle',
+ *        'sonar.projectKey': 'capralifecycle_my-project',
+ *      ])
+ */
+def call(Map<String, String> params, Map<String, String> options = [:]) {
+  analyzeSonarCloud(
+    [
+      'sonar.coverage.jacoco.xmlReportPaths': 'target/site/jacoco/jacoco.xml',
+      'sonar.sources': 'src/main',
+      'sonar.tests': 'src/test',
+      'sonar.exclusions': 'src/main/resources/**',
+      'sonar.test.exclusions': 'src/test/resources/**',
+      'sonar.java.binaries': 'target/classes',
+      'sonar.java.libraries': 'target/*.jar',
+      'sonar.java.test.libraries': 'target/*.jar',
+    ] + params,
+    options,
+  )
+}

--- a/vars/insideSonarScanner.groovy
+++ b/vars/insideSonarScanner.groovy
@@ -1,0 +1,14 @@
+#!/usr/bin/groovy
+
+/**
+ * Run inside a container having sonar-scanner installed.
+ *
+ * See withMavenSettings for how to use Maven settings
+ */
+def call(body) {
+  def img = docker.image('923402097046.dkr.ecr.eu-central-1.amazonaws.com/buildtools/tool/sonar-scanner')
+  img.pull() // ensure we have latest version
+  img.inside {
+    body()
+  }
+}


### PR DESCRIPTION
Internal details / coordination: https://confluence.capraconsulting.no/x/dA9aBw

A list of overrides in SonarCloud is available in the link above.

## To do

- [x] Set up test projects to adjust parameters
- [x] Test in a plain Java project
- [x] Test in a Kotlin project
- [x] Test in a TypeScript project
- [x] Test in a normal JS project
- [x] Review conflicting rules with Prettier - for now they are so few so manually ignored them in a test - review later when we have more projects onboard
- [x] Resolve TODOs in code
- [x] Adjust quality gate
- [x] Have someone review this

## After merging

- [ ] Remove branch override to pipeline library in test projects listed in https://confluence.capraconsulting.no/x/dA9aBw

## Other tasks outside this PR

- Review conflicting rules after more use
- Adjust quality gate etc. to fit our use (try to do this for all projects to avoid "random" differences)
- Add build badges to repos - not sure how it will work for private repos

## To be considered later

- We might want to put the analyze commands in a finally-block to allow failing test results to be pushed to SonarCloud. Will need some more testing to do this properly. For now a failing build will need to be fixed anyways.