### PR TITLE
Add initial version of maven build helper

### DIFF
--- a/src/no/capraconsulting/buildtools/mavenpipeline/MavenPipeline.groovy
+++ b/src/no/capraconsulting/buildtools/mavenpipeline/MavenPipeline.groovy
@@ -77,7 +77,7 @@ def createBuild(Closure cl) {
   checkNotNull(buildConfig.dockerBuildImage, 'dockerBuildImage')
 
   def build = { config ->
-    dockerNode {
+    dockerNode([label: buildConfig.dockerNodeLabel]) {
       def buildImage = docker.image(buildConfig.dockerBuildImage)
       buildImage.pull() // Ensure latest version
 
@@ -174,6 +174,8 @@ class ConfigDelegate implements Serializable {
 }
 
 class CreateBuildDelegate implements Serializable {
+  /** Optional override of Jenkins slave node label. */
+  String dockerNodeLabel
   String dockerBuildImage
   /** Optional extra args to mvn command. */
   String mavenArgs = ''


### PR DESCRIPTION
Uses strategy similar as in https://github.com/capralifecycle/jenkins-pipeline-library/pull/11, except the `buildConfig` is called by the pipeline lib so that we later can inject build properties (e.g. parameters for release).

Example `Jenkinsfile`:

```groovy
#!/usr/bin/env groovy

// See https://github.com/capralifecycle/jenkins-pipeline-library
@Library('cals@maven') _

import no.capraconsulting.buildtools.mavenpipeline.MavenPipeline

def p = new MavenPipeline()
p.pipeline {
  // Optional, but we need it to configure Slack for the job.
  buildConfigParams = [
    // Some time in the future we can infer this from the repo name and looking it up somewhere,
    // e.g. in resources-definition.
    slack: [
      channel: '#cals-dev-info',
      teamDomain: 'cals-capra',
    ],
  ],
  build = p.createBuild {
    dockerBuildImage = '923402097046.dkr.ecr.eu-central-1.amazonaws.com/buildtools/tool/maven:3-jdk-8-alpine'
  }
}
```

I think we should be fine extending this to add release behaviour, etc. I have chosen not to include a number in the name (different than e.g. `webapp1`) to avoid confusion around maven version.

## After merge

- Changes pipeline references to the PR-branch back to `master`

## To do later

- Add SonarCloud integration
- Deploy snapshots for specific branches
- Add release behaviour for specific branches
- Docker build