### PR TITLE
add cdk snapshot verification

### DIFF
--- a/vars/verifyCdkSnapshots.groovy
+++ b/vars/verifyCdkSnapshots.groovy
@@ -1,0 +1,28 @@
+#!/usr/bin/groovy
+
+/**
+ * Verify CDK snapshots.
+ *
+ * Example usage:
+ *
+ *  stage("Verify CDK snapshots") {
+ *    verifyCdkSnapshots()
+ *  }
+ *
+ */
+def call(Map args = [:]) {
+  def snapshotCommand = args.snapshotCommand ?: "npm run snapshots"
+  def snapshotDir = args.snapshotDir ?: "__snapshots__"
+  echo "Verifying CDK snapshots"
+  sh """
+    snapshot_dir="${snapshotDir}"
+    if [ ! -d "\$snapshot_dir" ]; then
+      echo "Missing expected snapshot folder: \$snapshot_dir"
+      exit 1
+    fi
+    ${snapshotCommand}
+    git status
+    git add -N "\$snapshot_dir"
+    git diff --exit-code
+  """
+}


### PR DESCRIPTION
Add a global variable that can be used to run our CDK snapshot verification, returning a non-zero exit code if the snapshot directory is missing or if there is any kind of diff in the snapshot directory (including untracked files).