### PR TITLE
feat: authenticate to ecr public to increase rate limit

### DIFF
--- a/vars/dockerNode.groovy
+++ b/vars/dockerNode.groovy
@@ -22,6 +22,9 @@ def call(Map args = [:], body) {
     // to use ECR for pulling and pushing our own Docker images.
     sh '(set +x; eval $(aws ecr get-login --no-include-email --region eu-central-1))'
 
+    // Authenticate to ECR Public to increase rate limit
+    sh '(set +x; aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws)'
+
     withCredentials([
       usernamePassword(
         credentialsId: 'dockerhub-token-with-user',


### PR DESCRIPTION
This should raise our rate limit from 1 to 10 image pulls per second when pulling images from ECR Public.